### PR TITLE
oca_install_addons - revert performance hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,8 @@ RUN pipx install --pip-args="--no-cache-dir" manifestoo>=0.3
 RUN pipx install --pip-args="--no-cache-dir" acsoo==3.0.2
 COPY bin/addons /usr/local/bin
 
-# Install setuptools-odoo-get-requirements helper script
+# Install setuptools-odoo-get-requirements and setuptools-odoo-makedefault helper
+# scripts.
 RUN pipx install --pip-args="--no-cache-dir" "setuptools-odoo>=3.0.1"
 
 # Make a virtualenv for Odoo so we isolate from system python dependencies and

--- a/bin/oca_install_addons
+++ b/bin/oca_install_addons
@@ -1,25 +1,28 @@
 #!/bin/bash
 
 #
-# Install dependencies of addons to test, and add addons to test to Odoo's addons_path.
-#
-# An alternative technique would be to install all addons with `pip install --editable`
-# but it is relatively slow in repos with a large number of addons.
+# Install addons to test (in editable mode) and their dependencies.
 #
 
 set -ex
 
-# Compute and install direct dependencies of installable addons in $ADDONS_DIR
-# (this includes addons, python external dependencies and odoo itself)
-setuptools-odoo-get-requirements --include-addons --addons-dir ${ADDONS_DIR} >> test-requirements.txt
+# Pre-install setuptools-odoo as an optimization. Without this,
+# setuptools-odoo will be installed repeatedly for each addon in the repo
+# which significantly slows down installation in repos with many addons.
+pip install "setuptools-odoo>=2.7"
+# Disable the post versioning strategy as we don't need the exact versions
+# and this also speeds-up installation a little bit.
+export SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE=none
+
+# Install addons in current repo in editable mode, so coverage will see them.
+touch test-requirements.txt
+for addon in $(addons --addons-dir "${ADDONS_DIR}" --include "${INCLUDE}" --exclude "${EXCLUDE}" --separator " " list) ; do
+    echo "-e ./setup/${addon}" >> test-requirements.txt
+done
 cat test-requirements.txt
 pip install -r test-requirements.txt
 pip config list
 pip list
-
-# Add ADDONS_DIR to addons_path.
-echo "addons_path=/opt/odoo/addons,${ADDONS_DIR}" >> ${ODOO_RC}
-cat ${ODOO_RC}
 
 # Install 'deb' external dependencies of all Odoo addons found in path.
 DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends $(oca_list_external_dependencies deb)

--- a/tests/common.py
+++ b/tests/common.py
@@ -64,6 +64,16 @@ def install_test_addons(test_addons):
     with preserve_odoo_rc(), preserve_odoo_venv(), make_addons_dir(
         test_addons
     ) as addons_dir:
+        subprocess.check_call(
+            [
+                "setuptools-odoo-make-default",
+                "-d",
+                ".",
+                "--odoo-version-override",
+                os.environ["ODOO_VERSION"],
+            ],
+            cwd=addons_dir,
+        )
         subprocess.check_call(["oca_install_addons"], cwd=addons_dir)
         yield addons_dir
 
@@ -74,7 +84,7 @@ def dropdb():
 
 def did_run_test_module(output, test_module):
     """Check that a test did run by looking in the Odoo log.
-    
+
     test_module is the full name of the test (addon_name.tests.test_module).
     """
     return "odoo.addons." + test_module in output


### PR DESCRIPTION
Using setuptools-odoo-get-requirements is a performance hack and is currently buggy for Odoo 15 (https://github.com/acsone/setuptools-odoo/issues/67).
And the gain might not be that significant after all, let's see.

Installing addons in editable mode is simpler as we let the pip resolver do all the work.