### PR TITLE
Improve addons installatoin performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ COPY bin/addons /usr/local/bin
 
 # Install setuptools-odoo-get-requirements and setuptools-odoo-makedefault helper
 # scripts.
-RUN pipx install --pip-args="--no-cache-dir" "setuptools-odoo>=3.0.1"
+RUN pipx install --pip-args="--no-cache-dir" "setuptools-odoo>=3.0.7"
 
 # Make a virtualenv for Odoo so we isolate from system python dependencies and
 # make sure addons we test declare all their python dependencies properly
@@ -152,6 +152,7 @@ ENV PIP_NO_PYTHON_VERSION_WARNING=1
 # Control addons discovery. INCLUDE and EXCLUDE are comma-separated list of
 # addons to include (default: all) and exclude (default: none)
 ENV ADDONS_DIR=.
+ENV ADDONS_PATH=/opt/odoo/addons,${ADDONS_DIR}
 ENV INCLUDE=
 ENV EXCLUDE=
 ENV OCA_GIT_USER_NAME=oca-ci

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Environment variables:
 - `PIP_DISABLE_PIP_VERSION_CHECK=1`
 - `PIP_NO_PYTHON_VERSION_WARNING=1`
 - `ADDONS_DIR=.`
+- `ADDONS_PATH=/opt/odoo/addons,${ADDONS_DIR}`
 - `INCLUDE=`
 - `EXCLUDE=`
 - `OCA_GIT_USER_NAME=oca-ci`: git user name to commit `.pot` files
@@ -43,7 +44,7 @@ Available commands:
 
 - `oca_install_addons`: make addons to test (found in `$ADDONS_DIR`, modulo
   `$INCLUDE` an `$EXCLUDE`) and their dependencies available in the Odoo addons
-  path.
+  path. Append `addons_path=${ADDONS_PATH}` to `$ODOO_RC`. 
 - `oca_init_test_database`: create a test database named `$PGDATABASE` with
   direct dependencies of addons to test installed in it
 - `oca_run_tests`: run tests of addons on `$PGDATABASE`, with coverage.

--- a/bin/oca_install_addons
+++ b/bin/oca_install_addons
@@ -1,40 +1,28 @@
 #!/bin/bash
 
 #
-# Install addons to test (in editable mode) and their dependencies.
+# Install dependencies of addons to test, and add addons to test to Odoo's addons_path.
+#
+# An alternative technique would be to install all addons with `pip install --editable`
+# but it is relatively slow in repos with a large number of addons. This is an area
+# where pip and/or setuptools could improve.
 #
 
 set -ex
 
-# Pre-install setuptools-odoo as an optimization. Without this,
-# setuptools-odoo will be installed repeatedly for each addon in the repo
-# which significantly slows down installation in repos with many addons.
-pip install "setuptools-odoo>=2.7"
-# Disable the post versioning strategy as we don't need the exact versions
-# and this also speeds-up installation a little bit.
-export SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE=none
-
-# Generate setup directories, in case they are not in the repo yet.
-setuptools-odoo-make-default -d ${ADDONS_DIR}
-
-# We need to help older pip versions running on python 2 and 3.5 (i.e. for Odoo <= 11),
-# by giving it the package name via the #egg fragment in pip install -e. Where we can
-# use the latest pip, `pip install -e setup/${addon}` works fine.
-DIST_PREFIX_VERSION=$(echo $ODOO_VERSION | cut -d '.' -f 1)
-if [[ $DIST_PREFIX_VERSION -ge 15 ]]
-then
-    DIST_PREFIX_VERSION=""
-fi
+# Compute and install direct dependencies of installable addons in $ADDONS_DIR
+# (this includes addons, python external dependencies and odoo itself)
+setuptools-odoo-get-requirements --include-addons --addons-dir ${ADDONS_DIR} >> test-requirements.txt
 
 # Install addons in current repo in editable mode, so coverage will see them.
-touch test-requirements.txt
-for addon in $(addons --addons-dir "${ADDONS_DIR}" --include "${INCLUDE}" --exclude "${EXCLUDE}" --separator " " list) ; do
-    echo "-e file://$(realpath ${ADDONS_DIR})/setup/${addon}#egg=odoo${DIST_PREFIX_VERSION}-addon-${addon}" >> test-requirements.txt
-done
 cat test-requirements.txt
 pip install -r test-requirements.txt
 pip config list
 pip list
+
+# Add ADDONS_DIR to addons_path.
+echo "addons_path=${ADDONS_PATH}" >> ${ODOO_RC}
+cat ${ODOO_RC}
 
 # Install 'deb' external dependencies of all Odoo addons found in path.
 DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends $(oca_list_external_dependencies deb)

--- a/tests/test_addons_path.py
+++ b/tests/test_addons_path.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import os
+
+from .common import install_test_addons
+
+
+def test_addons_path():
+    """Test must not fail where there are no installable addons."""
+    assert (
+        Path(os.environ["ODOO_RC"]).read_text()
+        == "[options]\n"
+    )
+    with install_test_addons(["addon_success"]):
+        assert (
+            Path(os.environ["ODOO_RC"]).read_text()
+            == "[options]\naddons_path=/opt/odoo/addons,.\n"
+        )


### PR DESCRIPTION
Query dependencies and pip install these only.
Do not pip install project addons in editable mode, as this is relatively slow.

Add an ADDONS_PATH environment variable,
used to populate $ODOO_RC.