### PR TITLE
Add ADDONS_DIR to addons_path at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ ENV PIP_NO_PYTHON_VERSION_WARNING=1
 # Control addons discovery. INCLUDE and EXCLUDE are comma-separated list of
 # addons to include (default: all) and exclude (default: none)
 ENV ADDONS_DIR=.
-ENV ADDONS_PATH=/opt/odoo/addons,${ADDONS_DIR}
+ENV ADDONS_PATH=/opt/odoo/addons
 ENV INCLUDE=
 ENV EXCLUDE=
 ENV OCA_GIT_USER_NAME=oca-ci

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Environment variables:
 - `PIP_DISABLE_PIP_VERSION_CHECK=1`
 - `PIP_NO_PYTHON_VERSION_WARNING=1`
 - `ADDONS_DIR=.`
-- `ADDONS_PATH=/opt/odoo/addons,${ADDONS_DIR}`
+- `ADDONS_PATH=/opt/odoo/addons`
 - `INCLUDE=`
 - `EXCLUDE=`
 - `OCA_GIT_USER_NAME=oca-ci`: git user name to commit `.pot` files
@@ -44,7 +44,7 @@ Available commands:
 
 - `oca_install_addons`: make addons to test (found in `$ADDONS_DIR`, modulo
   `$INCLUDE` an `$EXCLUDE`) and their dependencies available in the Odoo addons
-  path. Append `addons_path=${ADDONS_PATH}` to `$ODOO_RC`. 
+  path. Append `addons_path=${ADDONS_PATH},${ADDONS_DIR}` to `$ODOO_RC`.
 - `oca_init_test_database`: create a test database named `$PGDATABASE` with
   direct dependencies of addons to test installed in it
 - `oca_run_tests`: run tests of addons on `$PGDATABASE`, with coverage.

--- a/bin/oca_install_addons
+++ b/bin/oca_install_addons
@@ -21,7 +21,7 @@ pip config list
 pip list
 
 # Add ADDONS_DIR to addons_path.
-echo "addons_path=${ADDONS_PATH}" >> ${ODOO_RC}
+echo "addons_path=${ADDONS_PATH},${ADDONS_DIR}" >> ${ODOO_RC}
 cat ${ODOO_RC}
 
 # Install 'deb' external dependencies of all Odoo addons found in path.


### PR DESCRIPTION
This is more intuitive, and has better backward compatibility (previous commit broke runboat).