### PR TITLE
[IMP] enable database manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN pip install --no-cache-dir -e /opt/odoo \
     && pip list
 
 # Make an empty odoo.cfg
-RUN echo "[options]" > /etc/odoo.cfg
+COPY etc/* /etc/
 ENV ODOO_RC=/etc/odoo.cfg
 ENV OPENERP_SERVER=/etc/odoo.cfg
 

--- a/etc/odoo.cfg
+++ b/etc/odoo.cfg
@@ -1,0 +1,5 @@
+[options]
+admin_passwd = admin
+list_db = true
+unaccent = true
+without_demo = false


### PR DESCRIPTION
On OCA repos, sometimes there are incompatible modules. Or, at least, modules that introduce pollute others' behaviors.

When doing functional tests of a PR and the DB already contains all addons for the branch, it's easy to find out a bug that really won't be a bug in the current PR, but instead a side effect of another addon in the same repo. Many times, that addon isn't even used in production and the flaky use case is irrelevant.

It's helpful to have the possibility of installing an empty database. This way, only the wanted addons can be installed, and there's less chance for unwanted side-effects.

On a recent real use case that we have recorded, a user lost 30 minutes in the functional review, only to uninstall modules that polluted the one he wanted to test. At the end, there were still failures that we're not sure if belong to the important module.

For these reasons, I'm configuring Odoo runboat instances to have the database manager enabled by default, with a standard password: `admin`.

I took the chance to add a couple of good default parameters for any database.

@moduon @rafaelbn 