### PR TITLE
Use a standard-based way to get dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,9 +95,10 @@ RUN pipx install --pip-args="--no-cache-dir" "virtualenv$virtualenv_constraint"
 # We use manifestoo to check licenses, development status and list addons and dependencies
 RUN pipx install --pip-args="--no-cache-dir" "manifestoo>=0.3.1"
 
-# Install setuptools-odoo-get-requirements and setuptools-odoo-makedefault helper
-# scripts.
-RUN pipx install --pip-args="--no-cache-dir" "setuptools-odoo>=3.0.7"
+# Install pyproject-dependencies helper scripts.
+ARG build_deps="setuptools-odoo wheel whool"
+RUN pipx install --pip-args="--no-cache-dir" pyproject-dependencies
+RUN pipx inject --pip-args="--no-cache-dir" pyproject-dependencies $build_deps
 
 # Make a virtualenv for Odoo so we isolate from system python dependencies and
 # make sure addons we test declare all their python dependencies properly

--- a/bin/oca_install_addons
+++ b/bin/oca_install_addons
@@ -5,14 +5,26 @@
 #
 # An alternative technique would be to install all addons with `pip install --editable`
 # but it is relatively slow in repos with a large number of addons. This is an area
-# where pip and/or setuptools could improve.
+# where pip could improve.
 #
 
 set -ex
+shopt -s nullglob  # in case there is setup.py nor pyproject.toml
 
 # Compute and install direct dependencies of installable addons in $ADDONS_DIR
-# (this includes addons, python external dependencies and odoo itself)
-setuptools-odoo-get-requirements --include-addons --addons-dir ${ADDONS_DIR} >> test-requirements.txt
+# (this includes addons, python external dependencies and odoo itself).
+# The environment variables are for better perfomance as we are interested in
+# the dependencies metadata only, and not the exact versions.
+# --no-isolation is for performance. The Dockerfile has setuptools-odoo and whool
+# preinstalled in the same environment as pyproject-dependencies.
+# --ignore-build-errors is needed to avoid errors with uninstallable addons.
+env SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE=none \
+    WHOOL_POST_VERSION_STRATEGY_OVERRIDE=none \
+    pyproject-dependencies \
+      --no-isolation \
+      --ignore-build-errors \
+      ${ADDONS_DIR}/*/pyproject.toml ${ADDONS_DIR}/setup/*/setup.py \
+      >> test-requirements.txt
 
 # Install addons in current repo in editable mode, so coverage will see them.
 cat test-requirements.txt


### PR DESCRIPTION
Prepare for the replacement of setup.py by pyproject.toml.