### PR TITLE
[IMP] Allow to specify number of workers through environment variable

### DIFF
--- a/bin/oca_run_tests
+++ b/bin/oca_run_tests
@@ -18,4 +18,5 @@ unbuffer coverage run --include "${ADDONS_DIR}/*" --branch \
     -d ${PGDATABASE} \
     -i ${ADDONS} \
     --test-enable \
+    --workers=${WORKERS:-0} \
     --stop-after-init


### PR DESCRIPTION
We are running a test that involves the generation of several reports. 
The process would look something like:
```python
    report_pdf = (
        self.env.ref("module.name_report")
        .with_context(force_report_rendering=True)
        ._render_qweb_pdf([obj.id])
    )
```

We set the [ `force_report_rendering`](https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/models/ir_actions_report.py#L817) flag to not render in HTML since we want to check the PDF result but this process does not finish since the main process is blocked by the same execution.

Increasing the workers this does not happen. By default I have left it at 0 which is the default.