### PR TITLE
Use latest versions of python libraries for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,23 +105,15 @@ ENV PATH=/opt/odoo-venv/bin:$PATH
 
 ARG odoo_version
 
-# Install Odoo requirements (use ADD for correct layer caching).
-# We use requirements from OCB for easier maintenance of older versions.
-# We use no-binary for psycopg2 because its binary wheels are sometimes broken
-# and not very portable.
-ADD https://raw.githubusercontent.com/OCA/OCB/$odoo_version/requirements.txt /tmp/ocb-requirements.txt
-RUN pip install --no-cache-dir --no-binary psycopg2 -r /tmp/ocb-requirements.txt
-
-# Install other test requirements.
-# - coverage
-# - websocket-client is required for Odoo browser tests
-RUN pip install --no-cache-dir \
-  coverage \
-  websocket-client
-
-# Install Odoo (use ADD for correct layer caching)
+# Use ADD to rebuild from here when Odoo HEAD changes
 ARG odoo_org_repo=odoo/odoo
 ADD https://api.github.com/repos/$odoo_org_repo/git/refs/heads/$odoo_version /tmp/odoo-version.json
+
+# Install Odoo requirements.
+COPY requirements-${odoo_version}.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --no-binary psycopg2 -r /tmp/requirements.txt
+
+# Install Odoo (use ADD for correct layer caching)
 RUN mkdir /tmp/getodoo \
     && (curl -sSL https://github.com/$odoo_org_repo/tarball/$odoo_version | tar -C /tmp/getodoo -xz) \
     && mv /tmp/getodoo/* /opt/odoo \

--- a/requirements-11.0.txt
+++ b/requirements-11.0.txt
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/OCA/OCB/11.0/requirements.txt
+
+# other test requirements
+coverage
+websocket-client

--- a/requirements-12.0.txt
+++ b/requirements-12.0.txt
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/OCA/OCB/12.0/requirements.txt
+
+# other test requirements
+coverage
+websocket-client

--- a/requirements-13.0.txt
+++ b/requirements-13.0.txt
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/OCA/OCB/13.0/requirements.txt
+
+# other test requirements
+coverage
+websocket-client

--- a/requirements-14.0.txt
+++ b/requirements-14.0.txt
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/OCA/OCB/14.0/requirements.txt
+
+# other test requirements
+coverage
+websocket-client

--- a/requirements-15.0.txt
+++ b/requirements-15.0.txt
@@ -1,0 +1,16 @@
+# Add requirements and bounds that are missing from Odoo's setup.py.
+freezegun
+lxml-html-clean
+num2words
+pdfminer
+pypdf2<3
+rl-renderPM  # reportlab accelerator
+xlrd<2  # xlrd 2 dropped xlsx reading capability
+
+# We use no-binary for psycopg2 because its binary wheels are sometimes broken
+# and not very portable.
+--no-binary psycopg2
+
+# other test requirements
+coverage
+websocket-client

--- a/requirements-16.0.txt
+++ b/requirements-16.0.txt
@@ -1,0 +1,16 @@
+# Add requirements and bounds that are missing from Odoo's setup.py.
+freezegun
+lxml-html-clean
+num2words
+pdfminer
+pypdf2<3
+rl-renderPM  # reportlab accelerator
+xlrd<2  # xlrd 2 dropped xlsx reading capability
+
+# We use no-binary for psycopg2 because its binary wheels are sometimes broken
+# and not very portable.
+--no-binary psycopg2
+
+# other test requirements
+coverage
+websocket-client

--- a/requirements-17.0.txt
+++ b/requirements-17.0.txt
@@ -1,0 +1,16 @@
+# Add requirements and bounds that are missing from Odoo's setup.py.
+freezegun
+lxml-html-clean
+num2words
+pdfminer
+pypdf2<3
+rl-renderPM  # reportlab accelerator
+xlrd<2  # xlrd 2 dropped xlsx reading capability
+
+# We use no-binary for psycopg2 because its binary wheels are sometimes broken
+# and not very portable.
+--no-binary psycopg2
+
+# other test requirements
+coverage
+websocket-client


### PR DESCRIPTION
Odoo's requirements.txt pins old (sometimes very old) versions of python libraries. Their logic is to match what is available is some Debian versions they support.

There are downsides to testing with or relying on these versions:
- We sometimes fall into dependency hell traps (see the infamous cryptography/pyopenssl compatibility issues that pop up frequently) when addons require (directly or indirectly) more modern versions.
- These old libraries may have security issues (that are patched with Debian backports, but not on their corresponding PyPI version).

With this PR, we instead rely on the latest  versions, and we place upper bounds when there are known incompatibilities.

Another benefit of this approach is that we will detect early when there are incompatibilities with latest versions of these libraries. The corresponding downside is that it will create some noise when this happens, but it will be easy to update the requirements-*.txt here.

Another downside of this approach is that since we will  test with last versions, developers may start relying on latest feature that are not compatible with the old versions.

It's a question of tradeoffs of course. In my view this PR will likely bring more benefits than downsides and is worth trying.