### PR TITLE
Add keepalive for the scheduled ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,3 +172,10 @@ jobs:
           cache-to: type=inline
           push: true
         if: ${{ github.repository_owner == 'OCA' && github.ref == 'refs/heads/master' }}
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ CI on these images, be aware that, while we will not break things without
 reason, we will prioritize ease of maintenance for OCA over backward
 compatibility. ⚠️
 
-These images provide the following guarantees:
+They are rebuilt every day at 04:00 UTC, to always include latest odoo changes.
+
+They provide the following guarantees:
 
 - Odoo runtime dependencies are installed (`wkhtmltopdf`, `lessc`, etc).
 - Odoo source code is in `/opt/odoo`.


### PR DESCRIPTION
The scheduled ci workflow is disabled by Github whenever there hadn't been activity in the repository for at least 60 days:

![image](https://github.com/user-attachments/assets/3a1cfc50-472b-41d3-9b30-bd716dec8c8c)

As a consequence, tests in some oca addons repos can be failing if they depend on some recent odoo changes.

This PR adds a keepalive, relying on this [github action](https://github.com/marketplace/actions/workflow-keepalive). 