### PR TITLE
[ADD] oca_checklog_odoo: configurable failure on WARNING log messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,8 @@ RUN apt-get update -qq \
 
 # We use manifestoo to check licenses, development status and list addons and dependencies
 RUN pipx install --pip-args="--no-cache-dir" "manifestoo>=0.3.1"
+# Used in oca_checklog_odoo to check odoo logs for errors and warnings
+RUN pipx install --pip-args="--no-cache-dir" checklog-odoo
 
 # Install pyproject-dependencies helper scripts.
 ARG build_deps="setuptools-odoo wheel whool"
@@ -154,3 +156,4 @@ ENV INCLUDE=
 ENV EXCLUDE=
 ENV OCA_GIT_USER_NAME=oca-ci
 ENV OCA_GIT_USER_EMAIL=oca-ci@odoo-community.org
+ENV OCA_ENABLE_CHECKLOG_ODOO=

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Environment variables:
 - `EXCLUDE=`
 - `OCA_GIT_USER_NAME=oca-ci`: git user name to commit `.pot` files
 - `OCA_GIT_USER_EMAIL=oca-ci@odoo-community.org`: git user email to commit
+- `OCA_ENABLE_CHECKLOG_ODOO=`: enable odoo log error checking
   `.pot` files
 
 Available commands:
@@ -54,6 +55,7 @@ Available commands:
 - `oca_git_push_if_remote_did_not_change`: push local commits unless the remote
   tracked branch has evolved.
 - `oca_export_and_push_pot` combines the two previous commands.
+- `oca_checklog_odoo` checks odoo logs for errors (including warnings)
 
 ## Build
 

--- a/bin/oca_checklog_odoo
+++ b/bin/oca_checklog_odoo
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Check if odoo logs contain errors. Assumes logs will come from stdin
+#
+
+if [ -n "${OCA_ENABLE_CHECKLOG_ODOO}" ]; then
+    checklog-odoo
+else
+    cat
+fi

--- a/bin/oca_init_test_database
+++ b/bin/oca_init_test_database
@@ -5,7 +5,7 @@
 # installed. Use unbuffer to get a colored output.
 #
 
-set -ex
+set -exo pipefail
 
 oca_wait_for_postgres
 
@@ -18,4 +18,4 @@ fi
 unbuffer $(which odoo) \
   -d ${PGDATABASE} \
   -i ${ADDONS:-base} \
-  --stop-after-init
+  --stop-after-init | oca_checklog_odoo

--- a/bin/oca_run_tests
+++ b/bin/oca_run_tests
@@ -4,7 +4,7 @@
 # Run tests. Use unbuffer to get a colored output.
 #
 
-set -ex
+set -exo pipefail
 
 oca_wait_for_postgres
 
@@ -18,4 +18,4 @@ unbuffer coverage run --include "${ADDONS_DIR}/*" --branch \
     -d ${PGDATABASE} \
     -i ${ADDONS} \
     --test-enable \
-    --stop-after-init
+    --stop-after-init | oca_checklog_odoo

--- a/tests/data/addons/addon_warning/__manifest__.py
+++ b/tests/data/addons/addon_warning/__manifest__.py
@@ -1,0 +1,4 @@
+{
+    "name": "addon that generates warnings",
+    "version": "1.0.0",
+}

--- a/tests/data/addons/addon_warning/tests/__init__.py
+++ b/tests/data/addons/addon_warning/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_warning

--- a/tests/data/addons/addon_warning/tests/test_warning.py
+++ b/tests/data/addons/addon_warning/tests/test_warning.py
@@ -1,0 +1,9 @@
+import logging
+from odoo.tests.common import TransactionCase
+
+
+_logger = logging.getLogger(__name__)
+
+class Test(TransactionCase):
+    def test_log_warning(self):
+        _logger.warning("This is a warning")

--- a/tests/test_checklog.py
+++ b/tests/test_checklog.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+from .common import install_test_addons, dropdb, did_run_test_module
+
+
+def test_checklog_enabled():
+    """Test addon_warning with checklog enabled."""
+    with install_test_addons(["addon_warning"]) as addons_dir:
+        dropdb()
+        subprocess.check_call(["oca_init_test_database"], cwd=addons_dir)
+        os.environ["OCA_ENABLE_CHECKLOG_ODOO"] = "1"
+        result = subprocess.run(
+            ["oca_run_tests"], cwd=addons_dir, text=True, capture_output=True
+        )
+        os.environ["OCA_ENABLE_CHECKLOG_ODOO"] = ""
+        assert result.returncode == 1 and "Error: Errors detected in log." in result.stderr
+
+def test_checklog_disabled():
+    """Test addon_warning with checklog disabled."""
+    with install_test_addons(["addon_warning"]) as addons_dir:
+        dropdb()
+        subprocess.check_call(["oca_init_test_database"], cwd=addons_dir)
+        result = subprocess.check_output(
+            ["oca_run_tests"], cwd=addons_dir, text=True
+        )
+        assert did_run_test_module(result, "addon_warning.tests.test_warning")


### PR DESCRIPTION
This PR implements https://github.com/OCA/oca-ci/issues/10 by doing the following:
- Add `bin/oca_checklog_odoo`, which fails on stdin `WARNING` log messages when `OCA_ENABLE_CHECKLOG_ODOO` is set
- Pipe `oca_init_test_database` and `oca_run_tests` to  `oca_checklog_odoo`
- Test functionality in `tests/test_checklog.py`