### PR TITLE
[FIX] Install Chrome fixed version to avoid sudden errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,10 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     && apt-get update -qq \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qq postgresql-client-12
 
-# Install Google Chrome for browser tests
-RUN curl -sSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/chrome.deb \
-    && apt-get -y install --no-install-recommends /tmp/chrome.deb \
+# Install Google following Odoo's Runbot guideline https://github.com/odoo/runbot/blob/f8f435d468135486146a2e61e8d15d0f453c0e15/runbot/data/dockerfile_data.xml#L139-L140
+RUN curl -sSL https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.182-1_amd64.deb -o /tmp/chrome.deb \
+    && apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends /tmp/chrome.deb  \
     && rm /tmp/chrome.deb
 
 RUN add-apt-repository -y ppa:deadsnakes/ppa


### PR DESCRIPTION
Odoo's approach with Runbots is to install a fixed version of Chrome and only when a new version is tested across all the supported code base they bump it.

That way, they avoid sudden errors that would make the whole CIs collapse on tour tests. Like we're experiencing right now across several repos. Like for example: https://github.com/OCA/web/pull/2932

We can follow the guideline of Odoo's fixed versions for a minimum guarantee. Currently at https://github.com/odoo/runbot/commit/f18a1adfc387321dac907735e8c3a77a15b2607f

A good rationale by Odoo on why to fix Chrome versions: https://github.com/odoo/runbot/issues/732#issuecomment-1415642361

> On runbot.odoo.com we need to ensure that tests are consistent cross hosts and also that an update doesn't suddenly break tests. This is why the version is freezed.

> We usually upgrade the version when:
> 
> - a new feature is needed
> - the version is old and hides a real bug that we may have in the latest chrome release
> - the version is too old


cc @Tecnativa 

please review @sbidoul @pedrobaeza 