### PR TITLE
Drop support for python 3.5/ Odoo 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,11 +20,6 @@ jobs:
       matrix:
         include:
           # odoo/odoo
-          - python_version: "3.5"
-            codename: focal
-            odoo_version: "11.0"
-            odoo_org_repo: "odoo/odoo"
-            image_name: py3.5-odoo11.0
           - python_version: "3.6"
             codename: focal
             odoo_version: "12.0"
@@ -68,11 +63,6 @@ jobs:
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo17.0
           # oca/ocb
-          - python_version: "3.5"
-            codename: focal
-            odoo_version: "11.0"
-            odoo_org_repo: "oca/ocb"
-            image_name: py3.5-ocb11.0
           - python_version: "3.6"
             codename: focal
             odoo_version: "12.0"


### PR DESCRIPTION
The image builds fail on python 3.5, apparently for SSL certificates issue.

I propose to stop building the image. Already built images will remain available, so repos that use them will continue to work. But they won't get OCB updates anymore, if any.