### PR TITLE
Disable legacy install and enforce setuptools' editable_mode=compat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,31 +42,37 @@ jobs:
             odoo_version: "14.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.8-odoo14.0
+            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.8"
             codename: focal
             odoo_version: "15.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.8-odoo15.0
+            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.9"
             codename: focal
             odoo_version: "15.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.9-odoo15.0
+            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.10"
             codename: jammy
             odoo_version: "16.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo16.0
+            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.10"
             codename: jammy
             odoo_version: "17.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo17.0
+            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.10"
             codename: jammy
             odoo_version: "18.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo18.0
+            odoo_config_setting: "--config-setting=editable_mode=compat"
           # oca/ocb
           - python_version: "3.6"
             codename: focal
@@ -142,6 +148,7 @@ jobs:
             odoo_version=${{ matrix.odoo_version }}
             odoo_org_repo=${{ matrix.odoo_org_repo }}
             setuptools_constraint=${{ matrix.setuptools_constraint }}
+            odoo_config_setting=${{ matrix.odoo_config_setting }}
           tags: |
             ghcr.io/oca/oca-ci/${{ matrix.image_name }}:latest
           labels: |
@@ -164,6 +171,7 @@ jobs:
             odoo_version=${{ matrix.odoo_version }}
             odoo_org_repo=${{ matrix.odoo_org_repo }}
             setuptools_constraint=${{ matrix.setuptools_constraint }}
+            odoo_config_setting=${{ matrix.odoo_config_setting }}
           tags: |
             ghcr.io/oca/oca-ci/${{ matrix.image_name }}:latest
           labels: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,8 @@ RUN mkdir /tmp/getodoo \
     && (curl -sSL https://github.com/$odoo_org_repo/tarball/$odoo_version | tar -C /tmp/getodoo -xz) \
     && mv /tmp/getodoo/* /opt/odoo \
     && rmdir /tmp/getodoo
-RUN pip install --no-cache-dir -e /opt/odoo \
+ARG odoo_config_setting="--config-setting=editable_mode=compat"
+RUN pip install --no-cache-dir -e /opt/odoo $odoo_config_setting \
     && pip list
 
 # Make an empty odoo.cfg


### PR DESCRIPTION
Fixes #92 

The failure is probably due to this change in setuptools: https://github.com/pypa/setuptools/pull/4955, and would also have happened with pip 25.3 later this year with https://github.com/pypa/pip/issues/11457.

We need to pass this config settings for supported python versions that are compatible with that setuptools version, and we don't need it for OCB because it has https://github.com/odoo/odoo/pull/44001 which is not merged yet in upstream odoo.