### PR TITLE
Disable legacy uses of setuptools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,13 +25,11 @@ jobs:
             codename: focal
             odoo_version: "12.0"
             odoo_org_repo: "odoo/odoo"
-            setuptools_constraint: "<58"  # vatnumber needs setuptools with 2to3 support
             image_name: py3.6-odoo12.0
           - python_version: "3.6"
             codename: focal
             odoo_version: "13.0"
             odoo_org_repo: "odoo/odoo"
-            setuptools_constraint: "<58"  # vatnumber needs setuptools with 2to3 support
             image_name: py3.6-odoo13.0
           - python_version: "3.6"
             codename: focal
@@ -43,49 +41,41 @@ jobs:
             odoo_version: "14.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.8-odoo14.0
-            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.8"
             codename: focal
             odoo_version: "15.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.8-odoo15.0
-            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.9"
             codename: focal
             odoo_version: "15.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.9-odoo15.0
-            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.10"
             codename: jammy
             odoo_version: "16.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo16.0
-            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.10"
             codename: jammy
             odoo_version: "17.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo17.0
-            odoo_config_setting: "--config-setting=editable_mode=compat"
           - python_version: "3.10"
             codename: jammy
             odoo_version: "18.0"
             odoo_org_repo: "odoo/odoo"
             image_name: py3.10-odoo18.0
-            odoo_config_setting: "--config-setting=editable_mode=compat"
           # oca/ocb
           - python_version: "3.6"
             codename: focal
             odoo_version: "12.0"
             odoo_org_repo: "oca/ocb"
-            setuptools_constraint: "<58"  # vatnumber needs setuptools with 2to3 support
             image_name: py3.6-ocb12.0
           - python_version: "3.6"
             codename: focal
             odoo_version: "13.0"
             odoo_org_repo: "oca/ocb"
-            setuptools_constraint: "<58"  # vatnumber needs setuptools with 2to3 support
             image_name: py3.6-ocb13.0
           - python_version: "3.6"
             codename: focal
@@ -143,13 +133,12 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v6
         with:
+          file: "Dockerfile${{ matrix.python_version == '3.6' && '-legacypy' || '' }}"
           build-args: |
             codename=${{ matrix.codename }}
             python_version=${{ matrix.python_version }}
             odoo_version=${{ matrix.odoo_version }}
             odoo_org_repo=${{ matrix.odoo_org_repo }}
-            setuptools_constraint=${{ matrix.setuptools_constraint }}
-            odoo_config_setting=${{ matrix.odoo_config_setting }}
           tags: |
             ghcr.io/oca/oca-ci/${{ matrix.image_name }}:latest
           labels: |
@@ -166,13 +155,12 @@ jobs:
       - name: Push image
         uses: docker/build-push-action@v6
         with:
+          file: "Dockerfile${{ matrix.python_version == '3.6' && '-legacypy' || '' }}"
           build-args: |
             codename=${{ matrix.codename }}
             python_version=${{ matrix.python_version }}
             odoo_version=${{ matrix.odoo_version }}
             odoo_org_repo=${{ matrix.odoo_org_repo }}
-            setuptools_constraint=${{ matrix.setuptools_constraint }}
-            odoo_config_setting=${{ matrix.odoo_config_setting }}
           tags: |
             ghcr.io/oca/oca-ci/${{ matrix.image_name }}:latest
           labels: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 16
       fail-fast: false
       matrix:
         include:

--- a/Dockerfile-legacypy
+++ b/Dockerfile-legacypy
@@ -19,11 +19,6 @@ RUN apt-get update -qq \
 
 ENV PIPX_BIN_DIR=/usr/local/bin
 
-# Make pip work in standard-based mode only This disables use of deprecated
-# setup.py bdist_wheel and.py develop commands in favor of the PEP 517 and PEP
-# 660 interfaces.
-ENV PIP_USE_PEP517=1
-
 # Install wkhtml
 RUN case $(lsb_release -c -s) in \
       focal) WKHTML_DEB_URL=https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb ;; \
@@ -106,7 +101,7 @@ RUN pipx inject --pip-args="--no-cache-dir" pyproject-dependencies $build_deps
 # Make a virtualenv for Odoo so we isolate from system python dependencies and
 # make sure addons we test declare all their python dependencies properly
 RUN python$python_version -m venv /opt/odoo-venv \
-    && /opt/odoo-venv/bin/pip install -U "pip" \
+    && /opt/odoo-venv/bin/pip install -U "setuptools<58" "wheel" "pip" \
     && /opt/odoo-venv/bin/pip list
 ENV PATH=/opt/odoo-venv/bin:$PATH
 
@@ -138,7 +133,7 @@ RUN mkdir /tmp/getodoo \
     && (curl -sSL https://github.com/$odoo_org_repo/tarball/$odoo_version | tar -C /tmp/getodoo -xz) \
     && mv /tmp/getodoo/* /opt/odoo \
     && rmdir /tmp/getodoo
-RUN pip install --no-cache-dir -e /opt/odoo --config-setting=editable_mode=compat \
+RUN pip install --no-cache-dir -e /opt/odoo                         \
     && pip list
 
 # Make an empty odoo.cfg


### PR DESCRIPTION
This makes pip work in standards-based mode exclusively, and should also fix #97.

python 3.6 support is moved to a legacy Dockerfile