### PR TITLE
Don't use pgdg repo to install the postgresql client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,8 @@ RUN case $(lsb_release -c -s) in \
 RUN npm install -g rtlcss less@3.0.4 less-plugin-clean-css
 
 # Install postgresql client
-RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -s -c`-pgdg main" > /etc/apt/sources.list.d/pgclient.list \
-    && apt-get update -qq \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -qq postgresql-client-12
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq postgresql-client
 
 # Install Google following Odoo's Runbot guideline https://github.com/odoo/runbot/blob/f8f435d468135486146a2e61e8d15d0f453c0e15/runbot/data/dockerfile_data.xml#L139-L140
 RUN curl -sSL https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.182-1_amd64.deb -o /tmp/chrome.deb \

--- a/Dockerfile-legacypy
+++ b/Dockerfile-legacypy
@@ -43,10 +43,8 @@ RUN case $(lsb_release -c -s) in \
 RUN npm install -g rtlcss less@3.0.4 less-plugin-clean-css
 
 # Install postgresql client
-RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -s -c`-pgdg main" > /etc/apt/sources.list.d/pgclient.list \
-    && apt-get update -qq \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -qq postgresql-client-12
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq postgresql-client
 
 # Install Google following Odoo's Runbot guideline https://github.com/odoo/runbot/blob/f8f435d468135486146a2e61e8d15d0f453c0e15/runbot/data/dockerfile_data.xml#L139-L140
 RUN curl -sSL https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.182-1_amd64.deb -o /tmp/chrome.deb \


### PR DESCRIPTION
It's probably ok to use the default version that comes with the ubuntu distro.

fixes #100 