### PR TITLE
Remove OPENERP_SERVER env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,6 @@ RUN pip install --no-cache-dir -e /opt/odoo --config-setting=editable_mode=compa
 # Make an empty odoo.cfg
 RUN echo "[options]" > /etc/odoo.cfg
 ENV ODOO_RC=/etc/odoo.cfg
-ENV OPENERP_SERVER=/etc/odoo.cfg
 
 COPY bin/* /usr/local/bin/
 

--- a/Dockerfile-legacypy
+++ b/Dockerfile-legacypy
@@ -151,7 +151,6 @@ RUN pip install --no-cache-dir -e /opt/odoo                         \
 # Make an empty odoo.cfg
 RUN echo "[options]" > /etc/odoo.cfg
 ENV ODOO_RC=/etc/odoo.cfg
-ENV OPENERP_SERVER=/etc/odoo.cfg
 
 COPY bin/* /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Environment variables:
 
 - `ODOO_VERSION` (8.0, ..., 14.0, ...)
 - `ODOO_RC`
-- `OPENERP_SERVER=$ODOO_RC`
 - `PGHOST=postgres`
 - `PGUSER=odoo`
 - `PGPASSWORD=odoo`

--- a/tests/test_preinstalled.py
+++ b/tests/test_preinstalled.py
@@ -39,10 +39,6 @@ def test_odoo_rc():
     assert odoo_rc.read_text() == "[options]\n"
 
 
-def test_openerp_server_rc():
-    assert os.environ["OPENERP_SERVER"] == os.environ["ODOO_RC"]
-
-
 def test_import_odoo():
     subprocess.check_call(["python", "-c", "import odoo.addons"])
     subprocess.check_call(["python", "-c", "import odoo.cli"])


### PR DESCRIPTION
Odoo 19 logs a warning about it, and ODOO_RC is supported for all Odoo versions oca-ci supports.