### PR TITLE
[IMP]add http interface for the odoo config for 19 version

### DIFF
--- a/bin/oca_init_test_database
+++ b/bin/oca_init_test_database
@@ -18,4 +18,5 @@ fi
 unbuffer $(which odoo) \
   -d ${PGDATABASE} \
   -i ${ADDONS:-base} \
+  --http-interface=127.0.0.1 \
   --stop-after-init | oca_checklog_odoo

--- a/bin/oca_run_tests
+++ b/bin/oca_run_tests
@@ -18,4 +18,5 @@ unbuffer coverage run --include "${ADDONS_DIR}/*" --branch \
     -d ${PGDATABASE} \
     -i ${ADDONS} \
     --test-enable \
+    --http-interface=127.0.0.1 \
     --stop-after-init | oca_checklog_odoo


### PR DESCRIPTION
Tests are failing because of the warning.
Now in odoo 19, we have to have http_interface in the config file, else it is giving a warning https://github.com/odoo/odoo/blob/42880bc2526c04c8089988f22459977aad5c5f5e/odoo/tools/config.py#L729
 
 Fixing: https://github.com/OCA/oca-ci/issues/111