### PR TITLE
Avoid git repo ownership error

### DIFF
--- a/bin/oca_install_addons
+++ b/bin/oca_install_addons
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -ex
 
+# Since we run as root in a container, the ownership of the git directory
+# from action/checkout is different, and since the build process may invoke
+# git, it may fail with git introspection failed: fatal: detected dubious
+# ownership in repository at ... So we mark the current directory as safe.
+git config --global --add safe.directory $PWD
+
 # show pip config
 pip config list
 


### PR DESCRIPTION
This is to avoid errors such as `git introspection failed: fatal: detected dubious ownership in repository at /__w/repo/repo`.

Example failed job: https://github.com/OCA/wms/actions/runs/23597487754/job/68873558900